### PR TITLE
PriceLevel data structure changes, static test data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ Cargo.lock
 
 # MSVC Windows builds of rustc generate these, which store debugging information
 *.pdb
+
+# Benchmark input data
+orders.json

--- a/.justfile
+++ b/.justfile
@@ -32,6 +32,3 @@ gen:
 # run the simulation
 run:
     cargo run --release --bin generator | RUST_LOG=info cargo run --release
-
-data:
-    cargo run --release --bin generator

--- a/.justfile
+++ b/.justfile
@@ -33,3 +33,5 @@ gen:
 run:
     cargo run --release --bin generator | RUST_LOG=info cargo run --release
 
+data:
+    cargo run --release --bin generator

--- a/src/bin/generator.rs
+++ b/src/bin/generator.rs
@@ -7,30 +7,16 @@ use anyhow::Result;
 use merx::order::OrderRequest;
 use merx::order::util::generate;
 
+const FILE_PATH: &str = "./orders.json";
+
 fn main() -> Result<()> {
-    let mut stdout = io::stdout();
-
-    let input_exists = Path::new("./orders.json").try_exists();
-
-    match input_exists {
-        Ok(true) => {
-            // Do nothing, continue with the code
-        }
-        Ok(false) => {
-            let range = 1..=10_000_000;
-            let mut file = File::create("./orders.json")?;
-
-            for order in generate(range) {
-                let order = serde_json::to_string(&order).ok().unwrap();
-                writeln!(file, "{}", order)?;
-            }
-        }
-        Err(_) => {
-            // Error handling
-        }
+    if !Path::new(FILE_PATH).exists() {
+        generate_and_write_orders()?;
     }
 
-    let input = File::open("./orders.json")?;
+    let mut stdout = io::stdout();
+
+    let input = File::open(FILE_PATH)?;
     let reader = BufReader::new(input);
 
     let mut orders: Vec<OrderRequest> = Vec::new();
@@ -47,6 +33,18 @@ fn main() -> Result<()> {
         let order_json = serde_json::to_string(&order)?;
 
         writeln!(stdout, "{}", order_json)?;
+    }
+
+    Ok(())
+}
+
+fn generate_and_write_orders() -> io::Result<()> {
+    let range = 1..=10_000_000;
+    let mut file = File::create(FILE_PATH)?;
+
+    for order in generate(range) {
+        let order = serde_json::to_string(&order).ok().unwrap();
+        writeln!(file, "{}", order)?;
     }
 
     Ok(())

--- a/src/bin/generator.rs
+++ b/src/bin/generator.rs
@@ -1,15 +1,29 @@
 use std::io;
 use std::io::Write;
-
+use std::fs::File;
+use std::io::{BufRead, BufReader};
 use anyhow::Result;
-use merx::order::util::generate;
+use merx::order::OrderRequest;
 
 fn main() -> Result<()> {
     let mut stdout = io::stdout();
-    let range = 1..=10_000_000;
-    for order in generate(range) {
-        let order = serde_json::to_string(&order).ok().unwrap();
-        writeln!(stdout, "{}", order)?;
+    let input = File::open("./orders.json")?;
+    let reader = BufReader::new(input);
+
+    let mut orders: Vec<OrderRequest> = Vec::new();
+
+    for line in reader.lines() {
+        let line = line?;
+
+        let order: OrderRequest = serde_json::from_str(&line)?;
+
+        orders.push(order);
+    }
+    
+    for order in &orders {
+        let order_json = serde_json::to_string(&order)?;
+
+        writeln!(stdout, "{}", order_json)?;
     }
 
     Ok(())

--- a/src/bin/generator.rs
+++ b/src/bin/generator.rs
@@ -1,12 +1,35 @@
 use std::io;
 use std::io::Write;
 use std::fs::File;
+use std::path::Path;
 use std::io::{BufRead, BufReader};
 use anyhow::Result;
 use merx::order::OrderRequest;
+use merx::order::util::generate;
 
 fn main() -> Result<()> {
     let mut stdout = io::stdout();
+
+    let input_exists = Path::new("./orders.json").try_exists();
+
+    match input_exists {
+        Ok(true) => {
+            // Do nothing, continue with the code
+        }
+        Ok(false) => {
+            let range = 1..=10_000_000;
+            let mut file = File::create("./orders.json")?;
+
+            for order in generate(range) {
+                let order = serde_json::to_string(&order).ok().unwrap();
+                writeln!(file, "{}", order)?;
+            }
+        }
+        Err(_) => {
+            // Error handling
+        }
+    }
+
     let input = File::open("./orders.json")?;
     let reader = BufReader::new(input);
 

--- a/src/orderbook.rs
+++ b/src/orderbook.rs
@@ -131,7 +131,6 @@ type BidsLadder = LadderWrapper<BTreeMap<Reverse<OrderPrice>, PriceLevel>>;
 
 #[derive(Debug)]
 pub struct PriceLevel {
-    //order_ids: VecDeque<OrderId>,
     orders: VecDeque<Order>,
     quantity: OrderQuantity,
     price: OrderPrice,
@@ -140,7 +139,6 @@ pub struct PriceLevel {
 impl PriceLevel {
     fn new(price: OrderPrice) -> Self {
         Self {
-            //order_ids: VecDeque::with_capacity(DEFAULT_LEVEL_SIZE),
             orders: VecDeque::with_capacity(DEFAULT_LEVEL_SIZE),
             quantity: Decimal::ZERO,
             price,
@@ -245,11 +243,9 @@ macro_rules! match_order {
             let mut total_traded = OrderQuantity::ZERO;
             let mut orders_completed = 0;
 
-            for maker_order in price_level.iter_mut() {
-                let maker = maker_order;
-                // let test = $orders
-                //     .get_mut(order_id)
-                //     .ok_or(OrderbookError::OrderToMatchNotFound(*order_id))?;
+            for maker in price_level.iter_mut() {
+               // let maker = maker_order;
+      
                 let traded = $incoming_order.can_trade(maker);
 
                 let trade = Trade::new(&mut $incoming_order, maker, traded).map_err(OrderbookError::TradeError)?;


### PR DESCRIPTION
Added a suggestion for PriceLevel data structure changes. This should reduce execution time as we no longer need to query orders in order to find the maker's quantity in O(n). The suggested approach stores an actual order object in VecDeque from which order size is retrieved in O(1). There might be memory size implications, but still looking into it.

Also added logic for test data generation. Previously, test data was regenerated on every execution, thus changes in performance due to different test orders can make benchmarking unreliable. In this MR it saves test data into a file and loads it from it.

Adding some benchmark results for comparison:

New data structure for orders inside PriceLevel: 
```
{"timestamp":"2023-10-07T21:45:56.857212Z","level":"INFO","fields":{"message":"Matching Engine started!"},"target":"merx","threadName":"main"}
{"timestamp":"2023-10-07T21:46:14.686093Z","level":"INFO","fields":{"message":"Matching Engine finished in 5466 milliseconds"},"target":"merx","threadName":"main"}
{"timestamp":"2023-10-07T21:46:14.686127Z","level":"INFO","fields":{"message":"Best Bid:Some(6432.69) Best Ask:Some(7133.43) Spread: Some(700.74)"},"target":"merx","threadName":"main"}

{"timestamp":"2023-10-07T21:46:27.861368Z","level":"INFO","fields":{"message":"Matching Engine started!"},"target":"merx","threadName":"main"}
{"timestamp":"2023-10-07T21:46:45.984126Z","level":"INFO","fields":{"message":"Matching Engine finished in 5591 milliseconds"},"target":"merx","threadName":"main"}
{"timestamp":"2023-10-07T21:46:45.984164Z","level":"INFO","fields":{"message":"Best Bid:Some(6432.69) Best Ask:Some(7133.43) Spread: Some(700.74)"},"target":"merx","threadName":"main"}

{"timestamp":"2023-10-07T21:57:24.540243Z","level":"INFO","fields":{"message":"Matching Engine started!"},"target":"merx","threadName":"main"}
{"timestamp":"2023-10-07T21:57:41.996824Z","level":"INFO","fields":{"message":"Matching Engine finished in 5400 milliseconds"},"target":"merx","threadName":"main"}
{"timestamp":"2023-10-07T21:57:41.996863Z","level":"INFO","fields":{"message":"Best Bid:Some(6432.69) Best Ask:Some(7133.43) Spread: Some(700.74)"},"target":"merx","threadName":"main"}
```

Old data structure for orders inside PriceLevel
```
{"timestamp":"2023-10-07T21:48:34.236109Z","level":"INFO","fields":{"message":"Matching Engine started!"},"target":"merx","threadName":"main"}
{"timestamp":"2023-10-07T21:48:57.399146Z","level":"INFO","fields":{"message":"Matching Engine finished in 6951 milliseconds"},"target":"merx","threadName":"main"}
{"timestamp":"2023-10-07T21:48:57.399185Z","level":"INFO","fields":{"message":"Best Bid:Some(6432.69) Best Ask:Some(7133.43) Spread: Some(700.74)"},"target":"merx","threadName":"main"}

{"timestamp":"2023-10-07T21:50:09.171375Z","level":"INFO","fields":{"message":"Matching Engine started!"},"target":"merx","threadName":"main"}
{"timestamp":"2023-10-07T21:50:28.099638Z","level":"INFO","fields":{"message":"Matching Engine finished in 6342 milliseconds"},"target":"merx","threadName":"main"}
{"timestamp":"2023-10-07T21:50:28.099661Z","level":"INFO","fields":{"message":"Best Bid:Some(6432.69) Best Ask:Some(7133.43) Spread: Some(700.74)"},"target":"merx","threadName":"main"}

{"timestamp":"2023-10-07T21:50:53.874207Z","level":"INFO","fields":{"message":"Matching Engine started!"},"target":"merx","threadName":"main"}
{"timestamp":"2023-10-07T21:51:12.500634Z","level":"INFO","fields":{"message":"Matching Engine finished in 6309 milliseconds"},"target":"merx","threadName":"main"}
{"timestamp":"2023-10-07T21:51:12.500658Z","level":"INFO","fields":{"message":"Best Bid:Some(6432.69) Best Ask:Some(7133.43) Spread: Some(700.74)"},"target":"merx","threadName":"main"}

{"timestamp":"2023-10-07T21:56:46.261138Z","level":"INFO","fields":{"message":"Matching Engine started!"},"target":"merx","threadName":"main"}
{"timestamp":"2023-10-07T21:57:04.780286Z","level":"INFO","fields":{"message":"Matching Engine finished in 6279 milliseconds"},"target":"merx","threadName":"main"}
{"timestamp":"2023-10-07T21:57:04.780328Z","level":"INFO","fields":{"message":"Best Bid:Some(6432.69) Best Ask:Some(7133.43) Spread: Some(700.74)"},"target":"merx","threadName":"main"}
```